### PR TITLE
Add ability to limit folders to a particular parent folder in Set_Folder_Permissions_Recursive_BULK

### DIFF
--- a/Set_Folder_Permissions_recursive_BULK.ps1
+++ b/Set_Folder_Permissions_recursive_BULK.ps1
@@ -213,7 +213,7 @@ function Set-MailboxFolderPermissionsRecursive {
 }
 
 #Invoke the Set-MailboxFolderPermissionsRecursive function and pass the command line parameters. Make sure the output is stored in a variable for reuse, even if not specified in the input!
-if ($PSBoundParameters.Count) { Set-MailboxFolderPermissionsRecursive @PSBoundParameters -OutVariable global:varFolderPermissionsAdded }
+if ($PSBoundParameters.Count -and $PSBoundParameters.Keys -notmatch "WhatIf|Verbose|ErrorAction|ErrorVariable|Confirm|Debug|WarningAction|WarningVariable|InformationAction|InformationVariable|OutVariable|OutBuffer|PipelineVariable") {
+	Set-MailboxFolderPermissionsRecursive @PSBoundParameters -OutVariable global:varFolderPermissionsAdded 
+}
 else { Write-Host "INFO: The script was run without parameters, consider dot-sourcing it instead." -ForegroundColor Cyan }
-
-#Invoke-Command -Session $session -ScriptBlock { Remove-MailboxFolderPermission -Identity $Using:foldername -User $Using:u.Value -Confirm:$false }

--- a/Set_Folder_Permissions_recursive_BULK.ps1
+++ b/Set_Folder_Permissions_recursive_BULK.ps1
@@ -1,7 +1,7 @@
-﻿#Requires -Version 3.0
+#Requires -Version 3.0
 [CmdletBinding(SupportsShouldProcess)] #Make sure we can use -WhatIf and -Verbose
 Param(
-[switch]$Quiet,[ValidateNotNullOrEmpty()][Alias("Identity")][String[]]$Mailbox,[ValidateNotNullOrEmpty()][Alias("Delegate")][String[]]$User,
+[switch]$Quiet,[ValidateNotNullOrEmpty()][Alias("Identity")][String[]]$Mailbox,[ValidateNotNullOrEmpty()][Alias("Delegate")][String[]]$User,[Parameter(Mandatory=$false)][String]$ParentFolderPath,
 [ValidateSet("None","Owner","PublishingEditor","Editor","PublishingAuthor","Author","NoneditingAuthor","Reviewer","Contributor","FreeBusyTimeOnly","FreeBusyTimeAndSubjectAndLocation",
 "Custom","CreateItems","CreateSubfolders","DeleteAllItems","DeleteOwnedItems","EditAllItems","EditOwnedItems","FolderContact","FolderOwner","FolderVisible","ReadItems")]
 [ValidateNotNullOrEmpty()][String[]]$AccessRights)
@@ -23,22 +23,32 @@ function ReturnFolderList {
     Enumerates all user-accessible folders for the mailbox
 .DESCRIPTION
     The ReturnFolderList cmdlet enumerates the folders for the given mailbox. To adjust the list of folders, add to the $includedfolders or $excludedfolders array, respectively.
+.PARAMETER SMTPAddress
+	Use the -SMTPAddress parameter to designate the mailbox where the desired folders reside
+.PARAMETER ParentFolderPath
+	Use the -ParentFolderPath to designate a starting point for listing folders. For instance, use "/Inbox/From Accounting/" to get all subfolders of the 'From Accounting folder in your Inbox.
 .EXAMPLE
     ReturnFolderList user@domain.com
-
     This command will return a list of all user-accessible folders for the user@domain.com mailbox.
 .INPUTS
-    SMTP address of the mailbox.
+    SMTP address of the mailbox, with optional parent folder (full path).
 .OUTPUTS
     Array with information about the mailbox folders.
 #>
     
-    param([Parameter(Mandatory=$true, ValueFromPipeline=$true)]$SMTPAddress)
+    param(
+	[Parameter(Mandatory=$true, ValueFromPipeline=$true)]$SMTPAddress,
+	[Parameter(Mandatory=$false)]$ParentFolderPath)
 
     if (!$session -or ($session.State -ne "Opened")) { Write-Error "No active Exchange Remote PowerShell session detected, please connect first. To connect to ExO: https://technet.microsoft.com/en-us/library/jj984289(v=exchg.160).aspx" -ErrorAction Stop }
 
-    $MBfolders = Invoke-Command -Session $session -ScriptBlock { Get-MailboxFolderStatistics $using:SMTPAddress | Select-Object Name,FolderType,Identity } -HideComputerName -ErrorAction Stop
-    $MBfolders = $MBfolders | ? {($_.FolderType -eq "User created" -or $_.FolderType -in $includedfolders) -and ($_.Name -notin $excludedfolders)}
+    $MBfolders = Invoke-Command -Session $session -ScriptBlock { Get-MailboxFolderStatistics $using:SMTPAddress | Select-Object Name,FolderType,FolderPath,Identity } -HideComputerName -ErrorAction Stop
+    if($PSBoundParameters.ContainsKey('ParentFolderPath')) {
+		$MBfolders = $MBfolders | ? {($_.FolderType -eq "User created" -or $_.FolderType -in $includedfolders) -and ($_.Name -notin $excludedfolders) -and ($_.FolderPath -match $ParentFolderPath+"*")}
+	}
+	else {
+		$MBfolders = $MBfolders | ? {($_.FolderType -eq "User created" -or $_.FolderType -in $includedfolders) -and ($_.Name -notin $excludedfolders)}
+	}
 
     if (!$MBfolders) { return }
     else { return ($MBfolders | select Name,FolderType,Identity) }
@@ -55,6 +65,8 @@ function Set-MailboxFolderPermissionsRecursive {
     Use the -Mailbox parameter to designate the mailbox. Any valid Exchange mailbox identifier can be specified. Multiple mailboxes can be specified in a comma-separated list or array, see examples below.
 .PARAMETER User
     Use the -User parameter to designate the delegate. Any valid Exchange security principal identifier can be specified. Multiple delegates can be specified in a comma-separated list or array, see examples below.
+.PARAMETER ParentFolderPath
+	Use the -ParentFolderPath to designate a starting point for listing folders. For instance, use "/Inbox/From Accounting/" to get all subfolders of the 'From Accounting folder in your Inbox.
 .PARAMETER AccessRights
     Use the -AccessRights parameter to specify the permission level to be granted. For list of accepted permissions see for example: https://docs.microsoft.com/en-us/powershell/module/exchange/mailboxes/add-mailboxfolderpermission?view=exchange-ps
     Roles have precedence over individual permissions entries. If an existing permission entry for the same User is detected, it will be updated to match the newly provided value.
@@ -66,15 +78,12 @@ function Set-MailboxFolderPermissionsRecursive {
     The -Verbose switch provides additional details on the cmdlet progress, it can be useful when troubleshooting issues.
 .EXAMPLE
     Set-MailboxFolderPermissionsRecursive -Mailbox user@domain.com -User delegate@domain.com -AccessRights Editor
-
     This command add Editor level permissions on all user-accessible folders in the user@domain.com mailbox for the delegate@domain.com delegate.
 .EXAMPLE
     Set-MailboxFolderPermissionsRecursive -Mailbox shared@domain.com,room@domain.com -User delegate@domain.com -AccessRights Owner
-
     This command add Owner level permissions on all user-accessible folders in BOTH the room@domain.com and shared@domain.com mailboxes for the delegate@domain.com delegate.
 .EXAMPLE
     Set-MailboxFolderPermissionsRecursive -Mailbox (Get-Mailbox -RecipientTypeDetails RoomMailbox) -User delegate -AccessRights Owner -Verbose
-
     This command add Owner level permissions on all user-accessible folders in ALL Room mailboxes in the organization for the delegate.
 .INPUTS
     A mailbox identifier, permissions level and delegate identifier.
@@ -87,6 +96,7 @@ function Set-MailboxFolderPermissionsRecursive {
     Param(
     [Parameter(Mandatory=$true,ValueFromPipeline=$false)][ValidateNotNullOrEmpty()][Alias("Identity")][String[]]$Mailbox,
     [Parameter(Mandatory=$true,ValueFromPipeline=$false)][ValidateNotNullOrEmpty()][Alias("Delegate")][String[]]$User,
+	[Parameter(Mandatory=$false)]$ParentFolderPath,
     [Parameter(Mandatory=$true)][ValidateSet("None","Owner","PublishingEditor","Editor","PublishingAuthor","Author","NoneditingAuthor","Reviewer","Contributor","FreeBusyTimeOnly","FreeBusyTimeAndSubjectAndLocation",
     "Custom","CreateItems","CreateSubfolders","DeleteAllItems","DeleteOwnedItems","EditAllItems","EditOwnedItems","FolderContact","FolderOwner","FolderVisible","ReadItems")]
     [ValidateNotNullOrEmpty()][String[]]$AccessRights,
@@ -151,7 +161,8 @@ function Set-MailboxFolderPermissionsRecursive {
         Write-Verbose "Processing mailbox ""$smtp""..."
         Start-Sleep -Milliseconds 800 #Add some delay to avoid throttling...
         Write-Verbose "Obtaining folder list for mailbox ""$smtp""..."
-        $folders = ReturnFolderList $smtp
+        if($PSBoundParameters.ContainsKey('ParentFolderPath')) {$folders = ReturnFolderList $smtp $ParentFolderPath}
+		else { $folders = ReturnFolderList $smtp }
         Write-Verbose "A total of $($folders.count) folders found for $($smtp)."
 
         if (!$folders) { Write-Verbose "No matching folders found for $($smtp), skipping..." ; continue }


### PR DESCRIPTION
Added parameter to limit scope to a subset of folders as designated by a path to the parent folder (ie, /Inbox/From Accounting/)